### PR TITLE
Fix orphaned trash entries

### DIFF
--- a/docroot/WEB-INF/src/org/liferay/jukebox/service/impl/SongLocalServiceImpl.java
+++ b/docroot/WEB-INF/src/org/liferay/jukebox/service/impl/SongLocalServiceImpl.java
@@ -226,6 +226,11 @@ public class SongLocalServiceImpl extends SongLocalServiceBaseImpl {
 			}
 		}
 
+		// Trash
+
+		trashEntryLocalService.deleteEntry(
+			Song.class.getName(), songId);
+
 		return songPersistence.remove(songId);
 	}
 


### PR DESCRIPTION
Portlet left trash entries behind after emptying recycling bin.
I saw that other stock portlets explicitly remove trash entries.